### PR TITLE
fix: update gptel-extensions path to use cross-platform home directory

### DIFF
--- a/home/.spacemacs.d/init.el
+++ b/home/.spacemacs.d/init.el
@@ -224,7 +224,7 @@ This function should only modify configuration layer settings."
                                       ;;                     :fetcher github
                                       ;;                     :repo "joshcho/ChatGPT.el"))
                                       gptel
-                                      (gptel-extensions :location "/Users/rodk//.emacs.d/private/gptel-extensions.el/")
+                                      (gptel-extensions :location "~/.emacs.d/private/gptel-extensions.el/")
                                       
                                       direnv
                                       pinboard

--- a/home/dotspacemacs.org
+++ b/home/dotspacemacs.org
@@ -525,7 +525,7 @@ Using =fold-this= because vimish folding is unfortuntely too laggy on some large
   ;;                     :fetcher github
   ;;                     :repo "joshcho/ChatGPT.el"))
   gptel
-  (gptel-extensions :location "/Users/rodk//.emacs.d/private/gptel-extensions.el/")
+  (gptel-extensions :location "~/.emacs.d/private/gptel-extensions.el/")
 
 #+end_src
 


### PR DESCRIPTION
## Summary
Fixed the GPTel configuration to work cross-platform by updating the hardcoded macOS path to use tilde expansion.

## Changes
- Updated `gptel-extensions` location from `/Users/rodk//.emacs.d/private/gptel-extensions.el/` to `~/.emacs.d/private/gptel-extensions.el/`
- Fixed path in both `dotspacemacs.org` (source) and `init.el` (generated)
- Removed double slash typo in original path

## Impact
- GPTel will now load correctly on Linux and other platforms
- No functional changes to GPTel behavior, only path resolution

## Testing
- Restart Emacs/Spacemacs to load the updated configuration
- GPTel should load without path errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)