### PR TITLE
feat(hammerspoon): add app launch statistics tracking with graphical display

### DIFF
--- a/home/.hammerspoon/init.org
+++ b/home/.hammerspoon/init.org
@@ -705,7 +705,7 @@ The KSheet spoon provides for showing the keybindings for the currently active a
   hotkey.bind(magic, "z", appLauncher("Zotero"))
   hotkey.bind(hyper, ";", appLauncher('Spotify'))
   hotkey.bind(hyper, "0", centerOnMainDisplay)
-  hotkey.bind(hyper, "/", showAppStats)
+  hotkey.bind(magic, "/", showAppStats)
 #+end_src
 
 #+RESULTS:

--- a/home/.hammerspoon/init.org
+++ b/home/.hammerspoon/init.org
@@ -529,14 +529,43 @@ The KSheet spoon provides for showing the keybindings for the currently active a
        }
 
        _statsWindow = hs.webview.new(windowFrame)
-          :windowStyle({"titled", "closable", "utility", "HUD", "nonactivating"})
+          :windowStyle({"titled", "closable", "utility", "HUD"})
           :html(html)
           :allowTextEntry(false)
           :windowTitle("App Launch Statistics")
           :level(hs.drawing.windowLevels.floating)
           :show()
 
-       -- Auto-close on losing focus
+       -- Add ESC key handler to close window
+       local escWatcher = hs.eventtap.new({hs.eventtap.event.types.keyDown}, function(event)
+          local keyCode = event:getKeyCode()
+          if keyCode == 53 then -- ESC key
+             if _statsWindow then
+                _statsWindow:delete()
+                _statsWindow = nil
+                if escWatcher then
+                   escWatcher:stop()
+                end
+                return true
+             end
+          end
+          return false
+       end)
+       escWatcher:start()
+
+       -- Close window when it loses focus (click outside)
+       _statsWindow:windowCallback(function(action)
+          if action == "focusChange" then
+             if _statsWindow then
+                _statsWindow:delete()
+                _statsWindow = nil
+                if escWatcher then
+                   escWatcher:stop()
+                end
+             end
+          end
+       end)
+
        _statsWindow:bringToFront()
     end
 

--- a/home/.hammerspoon/init.org
+++ b/home/.hammerspoon/init.org
@@ -286,6 +286,259 @@ The KSheet spoon provides for showing the keybindings for the currently active a
 ** Helper Functions
 #+begin_src lua
     _centeredWindowsFormerPositions = {}
+    _appLaunchStats = {}
+    _statsFilePath = hs.configdir .. "/app_launch_stats.json"
+
+    -- Load app launch statistics from file
+    local function loadAppStats()
+       local file = io.open(_statsFilePath, "r")
+       if file then
+          local content = file:read("*a")
+          file:close()
+          local success, decoded = pcall(hs.json.decode, content)
+          if success and decoded then
+             _appLaunchStats = decoded
+          end
+       end
+    end
+
+    -- Save app launch statistics to file
+    local function saveAppStats()
+       local file = io.open(_statsFilePath, "w")
+       if file then
+          local encoded = hs.json.encode(_appLaunchStats)
+          file:write(encoded)
+          file:close()
+       end
+    end
+
+    -- Track app launch
+    local function trackAppLaunch(appName)
+       if not _appLaunchStats[appName] then
+          _appLaunchStats[appName] = {
+             count = 0,
+             lastLaunched = nil
+          }
+       end
+       _appLaunchStats[appName].count = _appLaunchStats[appName].count + 1
+       _appLaunchStats[appName].lastLaunched = os.time()
+       saveAppStats()
+    end
+
+    -- Display app launch statistics in graphical window
+    _statsWindow = nil
+
+    local function showAppStats()
+       -- Convert to sorted array
+       local statsArray = {}
+       local totalLaunches = 0
+       for appName, stats in pairs(_appLaunchStats) do
+          table.insert(statsArray, {
+             name = appName,
+             count = stats.count,
+             lastLaunched = stats.lastLaunched
+          })
+          totalLaunches = totalLaunches + stats.count
+       end
+
+       -- Sort by count (descending)
+       table.sort(statsArray, function(a, b)
+          return a.count > b.count
+       end)
+
+       -- Build HTML content
+       local html = [[
+       <!DOCTYPE html>
+       <html>
+       <head>
+          <style>
+             body {
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+                margin: 0;
+                padding: 20px;
+                background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+                color: #333;
+             }
+             .container {
+                max-width: 700px;
+                margin: 0 auto;
+                background: white;
+                border-radius: 12px;
+                box-shadow: 0 10px 40px rgba(0,0,0,0.3);
+                overflow: hidden;
+             }
+             .header {
+                background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+                color: white;
+                padding: 25px;
+                text-align: center;
+             }
+             .header h1 {
+                margin: 0;
+                font-size: 28px;
+                font-weight: 600;
+             }
+             .header .subtitle {
+                margin-top: 8px;
+                opacity: 0.9;
+                font-size: 14px;
+             }
+             .stats-table {
+                padding: 20px;
+             }
+             table {
+                width: 100%;
+                border-collapse: collapse;
+             }
+             th {
+                background: #f8f9fa;
+                padding: 12px;
+                text-align: left;
+                font-weight: 600;
+                color: #495057;
+                border-bottom: 2px solid #dee2e6;
+             }
+             td {
+                padding: 12px;
+                border-bottom: 1px solid #e9ecef;
+             }
+             tr:hover {
+                background: #f8f9fa;
+             }
+             .rank {
+                color: #6c757d;
+                font-weight: 600;
+                width: 50px;
+             }
+             .app-name {
+                font-weight: 500;
+                color: #212529;
+             }
+             .count {
+                font-weight: 600;
+                color: #667eea;
+                text-align: center;
+                width: 80px;
+             }
+             .last-used {
+                color: #6c757d;
+                font-size: 13px;
+                text-align: right;
+                width: 150px;
+             }
+             .empty-state {
+                text-align: center;
+                padding: 60px 20px;
+                color: #6c757d;
+             }
+             .footer {
+                padding: 15px 20px;
+                background: #f8f9fa;
+                text-align: center;
+                color: #6c757d;
+                font-size: 13px;
+                border-top: 1px solid #dee2e6;
+             }
+          </style>
+       </head>
+       <body>
+          <div class="container">
+             <div class="header">
+                <h1>📊 App Launch Statistics</h1>
+                <div class="subtitle">Total Launches: ]] .. totalLaunches .. [[</div>
+             </div>
+             <div class="stats-table">
+       ]]
+
+       if #statsArray == 0 then
+          html = html .. [[
+                <div class="empty-state">
+                   <h3>No statistics recorded yet</h3>
+                   <p>Start using your app launcher shortcuts to see statistics here.</p>
+                </div>
+          ]]
+       else
+          html = html .. [[
+                <table>
+                   <thead>
+                      <tr>
+                         <th class="rank">#</th>
+                         <th class="app-name">Application</th>
+                         <th class="count">Launches</th>
+                         <th class="last-used">Last Used</th>
+                      </tr>
+                   </thead>
+                   <tbody>
+          ]]
+
+          for i, stat in ipairs(statsArray) do
+             local lastUsed = "Never"
+             if stat.lastLaunched then
+                local timeDiff = os.time() - stat.lastLaunched
+                if timeDiff < 60 then
+                   lastUsed = "Just now"
+                elseif timeDiff < 3600 then
+                   lastUsed = string.format("%.0f min ago", timeDiff / 60)
+                elseif timeDiff < 86400 then
+                   lastUsed = string.format("%.0f hours ago", timeDiff / 3600)
+                else
+                   lastUsed = string.format("%.0f days ago", timeDiff / 86400)
+                end
+             end
+
+             html = html .. string.format([[
+                      <tr>
+                         <td class="rank">%d</td>
+                         <td class="app-name">%s</td>
+                         <td class="count">%d</td>
+                         <td class="last-used">%s</td>
+                      </tr>
+             ]], i, stat.name, stat.count, lastUsed)
+          end
+
+          html = html .. [[
+                   </tbody>
+                </table>
+          ]]
+       end
+
+       html = html .. [[
+             </div>
+             <div class="footer">
+                Press ESC or click outside to close
+             </div>
+          </div>
+       </body>
+       </html>
+       ]]
+
+       -- Close existing window if open
+       if _statsWindow then
+          _statsWindow:delete()
+          _statsWindow = nil
+       end
+
+       -- Create webview window
+       local mainScreen = hs.screen.mainScreen()
+       local mainFrame = mainScreen:frame()
+       local windowFrame = {
+          x = mainFrame.x + (mainFrame.w - 750) / 2,
+          y = mainFrame.y + (mainFrame.h - 600) / 2,
+          w = 750,
+          h = 600
+       }
+
+       _statsWindow = hs.webview.new(windowFrame)
+          :windowStyle({"titled", "closable", "utility", "HUD", "nonactivating"})
+          :html(html)
+          :allowTextEntry(false)
+          :windowTitle("App Launch Statistics")
+          :level(hs.drawing.windowLevels.floating)
+          :show()
+
+       -- Auto-close on losing focus
+       _statsWindow:bringToFront()
+    end
 
     local function centerOnMainDisplay()
        local win = window.focusedWindow()
@@ -310,7 +563,10 @@ The KSheet spoon provides for showing the keybindings for the currently active a
 
     local function appLauncher(app)
       return function()
-        launched = application.launchOrFocus(app) 
+        -- Track the app launch
+        trackAppLaunch(app)
+
+        launched = application.launchOrFocus(app)
         if not launched then
           launched = application.launchOrFocusByBundleID(app)
         end
@@ -449,6 +705,7 @@ The KSheet spoon provides for showing the keybindings for the currently active a
   hotkey.bind(magic, "z", appLauncher("Zotero"))
   hotkey.bind(hyper, ";", appLauncher('Spotify'))
   hotkey.bind(hyper, "0", centerOnMainDisplay)
+  hotkey.bind(hyper, "/", showAppStats)
 #+end_src
 
 #+RESULTS:
@@ -545,6 +802,12 @@ Make sure Hammerspoon cli is installed
 
 #+begin_src lua
   hs.ipc.cliInstall("/opt/homebrew")
+#+end_src
+
+Load app launch statistics
+
+#+begin_src lua
+  loadAppStats()
 #+end_src
 
 Heads up that we're done


### PR DESCRIPTION
## Summary
- Add comprehensive usage tracking for Hammerspoon app launcher shortcuts
- Implement beautiful graphical statistics viewer with modern UI
- Persist statistics to JSON file for historical tracking

## Features
- **Automatic Tracking**: Every app launch via Hyper+key shortcuts is automatically tracked
- **Persistent Storage**: Stats saved to `~/.hammerspoon/app_launch_stats.json`
- **Graphical Display**: Press `Hyper+/` to view statistics in a modern webview window
- **Rich Information**: Shows ranking, launch counts, and human-readable "last used" timestamps
- **Beautiful UI**: Modern design with gradient styling, table layout, and hover effects

## Implementation Details
- Added `trackAppLaunch()` function integrated into existing `appLauncher()` wrapper
- Created `showAppStats()` function that generates HTML content and displays in webview
- Added `loadAppStats()` and `saveAppStats()` for JSON persistence
- Statistics include count and timestamp for each application
- Display window is centered, floating, and can be closed with ESC or close button

## Test Plan
- [x] Tangle init.org to generate init.lua
- [x] Reload Hammerspoon configuration
- [x] Launch several apps using Hyper+key shortcuts
- [x] Press Hyper+/ to view statistics window
- [x] Verify statistics persist across Hammerspoon restarts
- [x] Confirm ranking and timestamps are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)