### PR TITLE
feat(cmux): Claude Code hooks and workspace auto-naming

### DIFF
--- a/docs/superpowers/specs/2026-03-21-cmux-tmux-hooks-design.md
+++ b/docs/superpowers/specs/2026-03-21-cmux-tmux-hooks-design.md
@@ -1,0 +1,63 @@
+# cmux + tmux: Claude Code Hooks Integration
+
+**Date:** 2026-03-21
+**Branch:** feat/cmux-tmux-hooks
+**Status:** Approved
+
+## Problem
+
+When running Claude Code inside a tmux session attached from a cmux pane, cmux receives no lifecycle signals. tmux sits between Claude and cmux's renderer, consuming OSC escape sequences. The `cmux notify` CLI (used by hooks) bypasses this via Unix socket IPC, but two issues remain:
+
+1. `CMUX_WORKSPACE_ID` is not propagated into tmux — `cmux notify` can't target the correct workspace tab.
+2. The `Notification` hook event (Claude blocked waiting for input) is not installed by default — the most important signal for the blue ring / attention indicator is missing.
+
+## Solution
+
+### 1. `ta()` function in `home/.zshrc`
+
+Wraps `tmux attach` to propagate cmux env vars into tmux's global environment before attaching. No-ops safely when cmux is not present.
+
+```bash
+function ta() {
+  if [ -n "$CMUX_WORKSPACE_ID" ]; then
+    tmux set-environment -g CMUX_WORKSPACE_ID "$CMUX_WORKSPACE_ID"
+    tmux set-environment -g CMUX_SOCKET_PATH "${CMUX_SOCKET_PATH:-/tmp/cmux.sock}"
+  fi
+  tmux attach "$@"
+}
+```
+
+### 2. `~/.claude/hooks/cmux-notify.sh`
+
+Hook script handling 4 events via `cmux notify` / `cmux set-status` over Unix socket (bypasses tmux terminal layer):
+
+| Event | Action |
+|-------|--------|
+| `Stop` | Notify "Session complete" |
+| `PostToolUse` (Task only) | Notify "Agent finished" |
+| `Notification` | Notify with Claude's message + "Waiting" subtitle |
+| `PreToolUse` | Set sidebar status pill showing current tool activity |
+
+### 3. `~/.claude/settings.json` hooks section
+
+Wire all 4 events to the hook script. `PostToolUse` uses matcher `Task`; others use empty matcher (match all).
+
+## Files Changed
+
+| File | Action | Repo-tracked |
+|------|--------|-------------|
+| `home/.zshrc` | Add `ta()` function | Yes |
+| `~/.claude/hooks/cmux-notify.sh` | Create | No (user-local) |
+| `~/.claude/settings.json` | Add hooks section | No (user-local) |
+
+## Why the Socket CLI Approach Works Through tmux
+
+`cmux notify` communicates via a Unix socket at `/tmp/cmux.sock`. This is pure IPC — it has nothing to do with the terminal hierarchy. A process running any number of tmux levels deep can call `cmux notify` and cmux will respond identically, as long as the socket is accessible and `CMUX_WORKSPACE_ID` is set.
+
+## Testing
+
+1. Start cmux, open a pane, run `tmux` inside it
+2. Use `ta` to attach (or re-attach) — verify `echo $CMUX_WORKSPACE_ID` works inside tmux
+3. Start Claude Code inside tmux
+4. Verify notifications appear in cmux sidebar when Claude stops, agents finish, or Claude waits for input
+5. Verify status pills update during tool use

--- a/docs/superpowers/specs/2026-03-21-cmux-tmux-hooks-design.md
+++ b/docs/superpowers/specs/2026-03-21-cmux-tmux-hooks-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-03-21
 **Branch:** feat/cmux-tmux-hooks
-**Status:** Approved
+**Status:** Approved (revised)
 
 ## Problem
 
@@ -13,18 +13,18 @@ When running Claude Code inside a tmux session attached from a cmux pane, cmux r
 
 ## Solution
 
-### 1. `ta()` function in `home/.zshrc`
+### 1. Propagate cmux context in `tmux-sessionizer`
 
-Wraps `tmux attach` to propagate cmux env vars into tmux's global environment before attaching. No-ops safely when cmux is not present.
+Inject `CMUX_WORKSPACE_ID` and `CMUX_SOCKET_PATH` into tmux's global environment on every session create/attach/switch. This is the correct injection point because `tmux-sessionizer` (bound to `Ctrl-F`) is the actual entry point for tmux sessions — not manual `tmux attach`.
+
+The injection is idempotent and handles workspace changes (detach from one cmux workspace, reattach from another).
 
 ```bash
-function ta() {
-  if [ -n "$CMUX_WORKSPACE_ID" ]; then
+# Propagate cmux context into tmux so hooks can notify the correct workspace
+if [[ -n "$CMUX_WORKSPACE_ID" ]]; then
     tmux set-environment -g CMUX_WORKSPACE_ID "$CMUX_WORKSPACE_ID"
     tmux set-environment -g CMUX_SOCKET_PATH "${CMUX_SOCKET_PATH:-/tmp/cmux.sock}"
-  fi
-  tmux attach "$@"
-}
+fi
 ```
 
 ### 2. `~/.claude/hooks/cmux-notify.sh`
@@ -46,7 +46,7 @@ Wire all 4 events to the hook script. `PostToolUse` uses matcher `Task`; others 
 
 | File | Action | Repo-tracked |
 |------|--------|-------------|
-| `home/.zshrc` | Add `ta()` function | Yes |
+| `~/bin/tmux-sessionizer` | Add cmux env propagation | Yes (symlinked) |
 | `~/.claude/hooks/cmux-notify.sh` | Create | No (user-local) |
 | `~/.claude/settings.json` | Add hooks section | No (user-local) |
 
@@ -54,10 +54,15 @@ Wire all 4 events to the hook script. `PostToolUse` uses matcher `Task`; others 
 
 `cmux notify` communicates via a Unix socket at `/tmp/cmux.sock`. This is pure IPC — it has nothing to do with the terminal hierarchy. A process running any number of tmux levels deep can call `cmux notify` and cmux will respond identically, as long as the socket is accessible and `CMUX_WORKSPACE_ID` is set.
 
+## Design Revision History
+
+- **v1:** Used `ta()` wrapper in `.zshrc` around `tmux attach`. Rejected because `tmux-sessionizer` is the actual session entry point — `ta()` was at the wrong level in the process tree.
+- **v2 (current):** Inject env vars in `tmux-sessionizer` before every attach/switch. Idempotent, handles workspace changes, no extra aliases needed.
+
 ## Testing
 
-1. Start cmux, open a pane, run `tmux` inside it
-2. Use `ta` to attach (or re-attach) — verify `echo $CMUX_WORKSPACE_ID` works inside tmux
+1. Start cmux, open a pane, use `Ctrl-F` to launch tmux-sessionizer
+2. Verify `echo $CMUX_WORKSPACE_ID` works inside the tmux session
 3. Start Claude Code inside tmux
 4. Verify notifications appear in cmux sidebar when Claude stops, agents finish, or Claude waits for input
 5. Verify status pills update during tool use

--- a/home/.claude/hooks/cmux-notify.sh
+++ b/home/.claude/hooks/cmux-notify.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# cmux + tmux Claude Code notification bridge
+# Works because cmux notify talks to /tmp/cmux.sock directly,
+# bypassing the tmux terminal layer entirely.
+
+[ -S "${CMUX_SOCKET_PATH:-/tmp/cmux.sock}" ] || exit 0
+
+EVENT=$(cat)
+EVENT_TYPE=$(echo "$EVENT" | jq -r '.hook_event_name // "unknown"')
+TOOL=$(echo "$EVENT" | jq -r '.tool_name // ""')
+
+# Pass --workspace so cmux rings the correct tab even when user is elsewhere
+WS_ARGS=()
+[ -n "$CMUX_WORKSPACE_ID" ] && WS_ARGS=(--workspace "$CMUX_WORKSPACE_ID")
+
+# One-shot: rename workspace to bare repo name on first hook invocation
+if [ -n "$CMUX_WORKSPACE_ID" ]; then
+    INIT_MARKER="/tmp/cmux-init-${CMUX_WORKSPACE_ID}"
+    if [ ! -f "$INIT_MARKER" ]; then
+        touch "$INIT_MARKER"
+        REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+        if [ -n "$REPO_ROOT" ]; then
+            cmux rename-workspace --workspace "$CMUX_WORKSPACE_ID" -- "$(basename "$REPO_ROOT")" 2>/dev/null
+        fi
+    fi
+fi
+
+case "$EVENT_TYPE" in
+    "Stop")
+        cmux notify --title "Claude Code" --body "Session complete" "${WS_ARGS[@]}"
+        ;;
+    "PostToolUse")
+        [ "$TOOL" = "Task" ] && \
+            cmux notify --title "Claude Code" --body "Agent finished" "${WS_ARGS[@]}"
+        ;;
+    "Notification")
+        MSG=$(echo "$EVENT" | jq -r '.message // "Needs your input"')
+        cmux notify --title "Claude Code" --subtitle "Waiting" --body "$MSG" "${WS_ARGS[@]}"
+        ;;
+    "PreToolUse")
+        case "$TOOL" in
+            "Bash")
+                CMD=$(echo "$EVENT" | jq -r '.tool_input.command // ""' | cut -c1-60)
+                cmux set-status claude "running: $CMD" --icon terminal --color "#ff9f0a" "${WS_ARGS[@]}"
+                ;;
+            "Edit"|"MultiEdit"|"Write")
+                FILE=$(echo "$EVENT" | jq -r '.tool_input.file_path // ""' | xargs basename 2>/dev/null)
+                cmux set-status claude "editing: $FILE" --icon pencil --color "#0a84ff" "${WS_ARGS[@]}"
+                ;;
+        esac
+        ;;
+esac

--- a/home/.hammerspoon/init.lua
+++ b/home/.hammerspoon/init.lua
@@ -208,12 +208,6 @@ hotkey.bind(magic, 'space', spotify.displayCurrentTrack)
 hotkey.bind(magic, 'h', setHeadphones)
 hotkey.bind(magic, 's', setSpeakers)
 
-Install:andUse("KSheet", {
-                 hotkeys = {
-                   toggle = { hyper, "-" }
-                 }
-})
-
 hs.loadSpoon("MouseCircle")
 spoon.MouseCircle:bindHotkeys({
   show = { meh, "m" }
@@ -750,7 +744,8 @@ local hotkeyList = {
   {mod = "magic", key = "c", desc = "Claude"},
   {mod = "hyper", key = "d", desc = "Dash"},
   {mod = "magic", key = "d", desc = "Discord"},
-  {mod = "hyper", key = "f", desc = "DBeaver"},
+  {mod = "hyper", key = "f", desc = "Fusion"},
+  {mod = "magic", key = "f", desc = "Finder"},
   {mod = "hyper", key = "g", desc = "Bambu Studio"},
   {mod = "hyper", key = "h", desc = "Hotkey Help"},
   {mod = "hyper", key = "i", desc = "Ghostty"},
@@ -1026,7 +1021,8 @@ hotkey.bind(hyper, "c", hs.toggleConsole)
 hotkey.bind(magic, "c", appLauncher('Claude'))
 hotkey.bind(hyper, "d", appLauncher('Dash'))
 hotkey.bind(magic, "d", appLauncher('Discord'))
-hotkey.bind(hyper, "f", appLauncher('DBeaver'))
+hotkey.bind(hyper, "f", appLauncher('Autodesk Fusion'))
+hotkey.bind(magic, "f", appLauncher('Finder'))
 hotkey.bind(hyper, "g", appLauncher('BambuStudio'))
 hotkey.bind(hyper, "i", appLauncher('Ghostty'))
 hotkey.bind(meh, "i", appLauncher('cmux'))

--- a/home/.hammerspoon/init.org
+++ b/home/.hammerspoon/init.org
@@ -22,15 +22,16 @@
 - [[#menu-hammer---spacemacs-style-modal-menu-manager-wip][Menu Hammer - Spacemacs style modal menu manager (wip)]]
 - [[#window-and-screen-manipulation][Window and Screen Manipulation]]
   - [[#window-snapping][Window Snapping]]
+  - [[#window-switching][Window Switching]]
 - [[#watchers][Watchers]]
   - [[#screen-watcher][Screen Watcher]]
   - [[#usb-device-watcher][USB Device Watcher]]
 - [[#url-dispatching-to-site-specific-browsers][URL dispatching to site-specific browsers]]
 - [[#global-key-bindings][Global Key Bindings]]
-- [[#show-application-keybindings][Show application keybindings]]
 - [[#find-mouse-pointer][Find Mouse Pointer]]
 - [[#fast-navigation-to-core-apps][Fast navigation to core apps]]
   - [[#helper-functions][Helper Functions]]
+  - [[#hotkey-help-display][Hotkey Help Display]]
   - [[#key-bindings][Key Bindings]]
 - [[#caffeinate][Caffeinate]]
 - [[#load-local-config][Load Local Config]]
@@ -348,17 +349,6 @@ What's playing?
   hotkey.bind(magic, 's', setSpeakers)
 #+end_src
 
-* Show application keybindings
-
-The KSheet spoon provides for showing the keybindings for the currently active application.
-
-#+begin_src lua
-  Install:andUse("KSheet", {
-                   hotkeys = {
-                     toggle = { hyper, "-" }
-                   }
-  })
-#+end_src
 
 * Find Mouse Pointer
 
@@ -912,7 +902,8 @@ The MouseCircle spoon draws a circle around the mouse pointer to help locate it.
     {mod = "magic", key = "c", desc = "Claude"},
     {mod = "hyper", key = "d", desc = "Dash"},
     {mod = "magic", key = "d", desc = "Discord"},
-    {mod = "hyper", key = "f", desc = "DBeaver"},
+    {mod = "hyper", key = "f", desc = "Fusion"},
+    {mod = "magic", key = "f", desc = "Finder"},
     {mod = "hyper", key = "g", desc = "Bambu Studio"},
     {mod = "hyper", key = "h", desc = "Hotkey Help"},
     {mod = "hyper", key = "i", desc = "Ghostty"},
@@ -1192,7 +1183,8 @@ The MouseCircle spoon draws a circle around the mouse pointer to help locate it.
   hotkey.bind(magic, "c", appLauncher('Claude'))
   hotkey.bind(hyper, "d", appLauncher('Dash'))
   hotkey.bind(magic, "d", appLauncher('Discord'))
-  hotkey.bind(hyper, "f", appLauncher('DBeaver'))
+  hotkey.bind(hyper, "f", appLauncher('Autodesk Fusion'))
+  hotkey.bind(magic, "f", appLauncher('Finder'))
   hotkey.bind(hyper, "g", appLauncher('BambuStudio'))
   hotkey.bind(hyper, "i", appLauncher('Ghostty'))
   hotkey.bind(meh, "i", appLauncher('cmux'))

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -130,15 +130,6 @@ ulimit -n 4096
 # EAT shell integration (Emacs)
 [ -n "$EAT_SHELL_INTEGRATION_DIR" ] && source "$EAT_SHELL_INTEGRATION_DIR/zsh"
 
-# cmux context propagation for tmux
-function ta() {
-  if [ -n "$CMUX_WORKSPACE_ID" ]; then
-    tmux set-environment -g CMUX_WORKSPACE_ID "$CMUX_WORKSPACE_ID"
-    tmux set-environment -g CMUX_SOCKET_PATH "${CMUX_SOCKET_PATH:-/tmp/cmux.sock}"
-  fi
-  tmux attach "$@"
-}
-
 # Local customizations
 if [[ -f ~/.zshrc.local ]]; then
   source ~/.zshrc.local

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -130,6 +130,15 @@ ulimit -n 4096
 # EAT shell integration (Emacs)
 [ -n "$EAT_SHELL_INTEGRATION_DIR" ] && source "$EAT_SHELL_INTEGRATION_DIR/zsh"
 
+# cmux context propagation for tmux
+function ta() {
+  if [ -n "$CMUX_WORKSPACE_ID" ]; then
+    tmux set-environment -g CMUX_WORKSPACE_ID "$CMUX_WORKSPACE_ID"
+    tmux set-environment -g CMUX_SOCKET_PATH "${CMUX_SOCKET_PATH:-/tmp/cmux.sock}"
+  fi
+  tmux attach "$@"
+}
+
 # Local customizations
 if [[ -f ~/.zshrc.local ]]; then
   source ~/.zshrc.local

--- a/home/bin/tmux-sessionizer
+++ b/home/bin/tmux-sessionizer
@@ -372,6 +372,12 @@ if [[ "$session_created" == "true" && "$ENABLE_TEMPLATES" == "true" ]]; then
     fi
 fi
 
+# Propagate cmux context into tmux so hooks can notify the correct workspace
+if [[ -n "$CMUX_WORKSPACE_ID" ]]; then
+    tmux set-environment -g CMUX_WORKSPACE_ID "$CMUX_WORKSPACE_ID"
+    tmux set-environment -g CMUX_SOCKET_PATH "${CMUX_SOCKET_PATH:-/tmp/cmux.sock}"
+fi
+
 # Attach or switch to session depending on context
 if [ -z "$TMUX" ]; then
     tmux attach -t "$session_name"


### PR DESCRIPTION
## Summary
- Track `cmux-notify.sh` Claude Code hook in dotfiles repo via homeshick
- Auto-rename cmux workspaces to bare git repo name (e.g., `dotfiles`) on first hook invocation, so workspaces created directly in cmux get proper titles
- Propagate cmux env vars (`CMUX_WORKSPACE_ID`, `CMUX_SOCKET_PATH`) into tmux sessions

## Test plan
- [ ] Open a new cmux workspace directly (not via cmux-sessionizer) in a git repo
- [ ] Start Claude Code — workspace should rename to the repo's basename
- [ ] Verify notifications and status pills still work correctly
- [ ] Confirm `homeshick link dotfiles` symlinks the hook properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)